### PR TITLE
add missing transaction tax

### DIFF
--- a/app/code/local/MagePal/GoogleTagManager/Block/Tm.php
+++ b/app/code/local/MagePal/GoogleTagManager/Block/Tm.php
@@ -73,6 +73,7 @@ class MagePal_GoogleTagManager_Block_Tm extends Mage_Core_Block_Template
                 'transactionId' => $order->getIncrementId(),
                 'transactionAffiliation' => Mage::app()->getStore()->getFrontendName(),
                 'transactionTotal' => $order->getBaseGrandTotal(),
+                'transactionTax' => $order->getBaseTaxAmount(),
                 'transactionShipping' => $order->getBaseShippingAmount(),
                 'discountCode' => $order->getCouponCode(),
                 'discountPrice' => $order->getDiscountAmount(),


### PR DESCRIPTION
I'm missing the tax in my ecommerce data. 
Please accept this PR to add BaseTaxAmount to transaction.
It's up to the user to create a new variable in GTM to get this data. 